### PR TITLE
Fix Lightbox Info button click handling and enlarge icon

### DIFF
--- a/src/pages/QRCodeGallery.tsx
+++ b/src/pages/QRCodeGallery.tsx
@@ -432,10 +432,13 @@ function QRCodeGalleryPage() {
         render={{
           controls: () => (
             <button
-              className="absolute top-4 right-28 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white"
-              onClick={() => setInfoOpen(true)}
+              className="absolute top-4 right-28 flex h-16 w-16 items-center justify-center rounded-full bg-black/50 text-white"
+              onClick={(e) => {
+                e.stopPropagation();
+                setInfoOpen(true);
+              }}
             >
-              <Info className="h-4 w-4" />
+              <Info className="h-8 w-8" />
             </button>
           ),
         }}


### PR DESCRIPTION
## Summary
- prevent Lightbox from closing when clicking the Info control and open the details drawer
- double the Info control size for better visibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e83bc8510833380a6c7343dfad834